### PR TITLE
Fix CMAKE_BUILD_TYPE cache binding in BuildType.cmake

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 # mksock - Changes <!-- omit in toc -->
 
 
+## 0.1.2 - 27th August 2026
+
+* Fixed **cmake/BuildType.cmake** so the default `CMAKE_BUILD_TYPE` is set correctly in the CMake cache (`set(CMAKE_BUILD_TYPE … CACHE …)` instead of `set(CACHE CMAKE_BUILD_TYPE …)`);
+
+
 ## 0.1.1 - 24th August 2026
 
 * Added Doxygen API documentation (**Doxyfile**, **doc/mainpage.md**, **generate_doxygen.sh**) and a section-1 man page (**doc/mksock.1**);

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 
 | Date                 | News Item                                          |
 | -------------------- | -------------------------------------------------- |
+| 27th August 2026     | [0.1.2 released](https://github.com/sistools/mksock/releases/tag/0.1.2) |
 | 24th August 2026     | [0.1.1 released](https://github.com/sistools/mksock/releases/tag/0.1.1) |
 | 7th August 2026      | [0.1.0 released](https://github.com/sistools/mksock/releases/tag/0.1.0) |
 | 3rd August 2026      | 0.0.1 released                                     |

--- a/cmake/BuildType.cmake
+++ b/cmake/BuildType.cmake
@@ -1,11 +1,10 @@
-
 # ######################################################################## #
 # File:     /cmake/BuildType.cmake
 #
 # Purpose:  CMake module file (for BuildType)
 #
 # Created:  16th October 2019
-# Updated:  25th October 2024
+# Updated:  27th August 2026
 #
 # ######################################################################## #
 
@@ -45,7 +44,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 
 	message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
 
-	set(CACHE CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}"
+	set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE
 		STRING "Choose the type of build." FORCE
 	)
 
@@ -56,4 +55,3 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # ############################## end of file ############################# #
-

--- a/doc/mksock.1
+++ b/doc/mksock.1
@@ -1,6 +1,6 @@
 .\" Copyright (c) 2025-2026, Matthew Wilson and Synesis Information Systems
 .\"
-.TH MKSOCK 1 "August 2026" "mksock 0.1.1" "User Commands"
+.TH MKSOCK 1 "August 2026" "mksock 0.1.2" "User Commands"
 .SH NAME
 mksock \- create a UNIX-domain socket
 .SH SYNOPSIS

--- a/mksock.h
+++ b/mksock.h
@@ -4,7 +4,7 @@
 
 #define SISTOOL_MKSOCK_VER_MAJOR        0
 #define SISTOOL_MKSOCK_VER_MINOR        1
-#define SISTOOL_MKSOCK_VER_PATCH        1
+#define SISTOOL_MKSOCK_VER_PATCH        2
 #define SISTOOL_MKSOCK_VER_ALPHABETA    0xFF
 
 


### PR DESCRIPTION
The module used set(CACHE CMAKE_BUILD_TYPE …), which does not set the build-type cache entry; use set(CMAKE_BUILD_TYPE … CACHE …) instead. Bump the patch version and refresh CHANGES, NEWS, and man-page version strings for 27th August 2026.